### PR TITLE
dataset.pull(): add filter by image_status

### DIFF
--- a/darwin/dataset.py
+++ b/darwin/dataset.py
@@ -98,8 +98,8 @@ class Dataset:
             )
             yield
 
-    def pull(self, image_status: str = ""):
-        """Downloads a rermote project (images and annotations) in the projects directory. """
+    def pull(self, image_status: str = None):
+        """Downloads a remote project (images and annotations) in the projects directory. """
         query = f"/datasets/{self.dataset_id}/export?format=json"
         if image_status:
             query += f"&image_status={image_status}"

--- a/darwin/dataset.py
+++ b/darwin/dataset.py
@@ -98,7 +98,7 @@ class Dataset:
             )
             yield
 
-    def pull(self, image_status: str = None):
+    def pull(self, image_status: Optional[str]):
         """Downloads a remote project (images and annotations) in the projects directory. """
         query = f"/datasets/{self.dataset_id}/export?format=json"
         if image_status is not None:

--- a/darwin/dataset.py
+++ b/darwin/dataset.py
@@ -98,11 +98,13 @@ class Dataset:
             )
             yield
 
-    def pull(self):
+    def pull(self, image_status: str = ""):
         """Downloads a rermote project (images and annotations) in the projects directory. """
-        response = self._client.get(
-            f"/datasets/{self.dataset_id}/export?format=json", raw=True
-        )
+        query = f"/datasets/{self.dataset_id}/export?format=json"
+        if image_status:
+            query += f"&image_status={image_status}"
+
+        response = self._client.get(query, raw=True)
         zip_file = io.BytesIO(response.content)
         if zipfile.is_zipfile(zip_file):
             z = zipfile.ZipFile(zip_file)

--- a/darwin/dataset.py
+++ b/darwin/dataset.py
@@ -101,7 +101,7 @@ class Dataset:
     def pull(self, image_status: str = None):
         """Downloads a remote project (images and annotations) in the projects directory. """
         query = f"/datasets/{self.dataset_id}/export?format=json"
-        if image_status:
+        if image_status is not None:
             query += f"&image_status={image_status}"
 
         response = self._client.get(query, raw=True)


### PR DESCRIPTION
This PR adds a new parameter in the `dataset.pull()` method called `image_status` that can be used to filter the images that are gonna be downloaded by their current status in Darwin (eg. "done" or "in review").

For example, `dataset.pull(image_status="done")` will download only those images that have been annotated and reviewed.